### PR TITLE
Fix macros inside self function declarations.

### DIFF
--- a/src/SelfFunctions.jl
+++ b/src/SelfFunctions.jl
@@ -117,6 +117,8 @@ function redef_call(self, fields)
   function rcall(x::Expr)
      if x.head == :call
        :($selfcall($(rcall(x.args[1])), $self, $(map(rcall, x.args[2:end])...)))
+     elseif x.head == :macrocall
+       rcall(macroexpand(x))
      elseif x.head == :.
        x
      elseif x.head == :quote

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -38,6 +38,10 @@ function namespace()
   return f5
 end
 
+macro m1(x)
+  x == :x ? :y : :x
+end
+@selffirst f7() = @m1(x) + y
 
 
 @test f1(t1,3) == 6
@@ -48,6 +52,7 @@ end
 @test !isdefined(:f5)
 @test namespace()(t1) == 2
 @test f6(t1) == 3
+@test f7(t1) == 4
 
 @test a1(t1,3) == 9
 @test a2(t1,3) == 1


### PR DESCRIPTION
Before, the generated `self` macro would tinker with macro arguments before they could be expanded, now it expands all macros before doing anything.
